### PR TITLE
SignupPage 수정사항

### DIFF
--- a/src/assets/TextFieldBox.tsx
+++ b/src/assets/TextFieldBox.tsx
@@ -142,7 +142,8 @@ const ErrorMessageWrapper = styled.div`
   width: 592px;
   height: 12px;
   padding-top: 5px;
-  gap: 8px;
+  padding-left: 18px;
+  gap: 4px;
   border: none;
   background: none;
 `;

--- a/src/assets/dropdown/dropDown.tsx
+++ b/src/assets/dropdown/dropDown.tsx
@@ -121,6 +121,7 @@ const AngleDown = styled.div<{ isOpen: boolean; isSelected: boolean }>`
   position: relative;
   bottom: 47px;
   left: 585px;
+  height: 0;
 
   svg > path {
     fill: ${(props) => (props.isOpen && !props.isSelected ? "#d85888" : "")};

--- a/src/pages/SignUp/SignUp2Page.tsx
+++ b/src/pages/SignUp/SignUp2Page.tsx
@@ -133,10 +133,14 @@ export default function SignUp2Page() {
     const phoneCheck = /^010\d{8}$/;
     const phoneFormatCheck = /^010-\d{4}-\d{4}$/;
     if (phoneState === "filled") {
-      if (!phoneCheck.test(phone) && !phoneFormatCheck.test(phone)) setPhoneState("error");
+      if (!phoneCheck.test(phone) && !phoneFormatCheck.test(phone))
+        setPhoneState("error");
       else {
         const newphoneNumber = phone;
-        const newPhone = newphoneNumber.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+        const newPhone = newphoneNumber.replace(
+          /(\d{3})(\d{4})(\d{4})/,
+          "$1-$2-$3"
+        );
 
         setPhone(newPhone);
       }

--- a/src/pages/SignUp/SignUp3Page.tsx
+++ b/src/pages/SignUp/SignUp3Page.tsx
@@ -92,14 +92,13 @@ const ButtonsWrapper = styled.div`
 const InfoMessageWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  gap: 16px;
+  gap: 4px;
   margin-left: 20px;
 `;
 
 const InfoImageWrapper = styled.div`
   position: relative;
-  display: flex;
-  flex-direction: row;
+  width: 12px;
 `;
 
 const CircleImage = styled.svg`

--- a/src/pages/SignUp/SignUp3Page.tsx
+++ b/src/pages/SignUp/SignUp3Page.tsx
@@ -99,6 +99,11 @@ type StateOptions =
   | "loading"
   | "password";
 
+type errorMessageType = {
+  passwordErrorMessage: string;
+  nicknameErrorMessage: string;
+};
+
 export default function SignUp3Page() {
   /* Prev/Next 버튼 동작에 따른 페이지(회원가입 단계) 이동 */
   const navigate = useNavigate();
@@ -110,18 +115,20 @@ export default function SignUp3Page() {
 
   /* 각 input들의 값을 state를 사용하여 관리 */
   const [ID, setID] = useState<string>("bruce1115@korea.ac.kr");
-  const [IDState, setIDState] = useState<StateOptions>("default");
   const [password, setPassword] = useState<string>("");
   const [passwordState, setPasswordState] = useState<StateOptions>("default");
   const [password2, setPassword2] = useState<string>("");
   const [password2State, setPassword2State] = useState<StateOptions>("default");
   const [nickname, setNickname] = useState<string>("");
   const [nicknameState, setnicknameState] = useState<StateOptions>("default");
+  const [errorMessages, setErrorMessages] = useState<errorMessageType>({
+    passwordErrorMessage: "",
+    nicknameErrorMessage: "",
+  });
 
   /* 모든 state가 빈 문자열이 아니면 선택이 완료된 것이므로 complete를 true로 전환한다. 반대도 마찬가지. */
   useEffect(() => {
     if (
-      IDState === "filled" &&
       passwordState === "filled" &&
       password2State === "filled" &&
       nicknameState === "filled" &&
@@ -130,7 +137,6 @@ export default function SignUp3Page() {
       setComplete(true);
     } else if (
       !(
-        IDState === "filled" &&
         passwordState === "filled" &&
         password2State === "filled" &&
         nicknameState === "filled"
@@ -139,36 +145,32 @@ export default function SignUp3Page() {
     ) {
       setComplete(false);
     }
-  }, [IDState, passwordState, password2State, nicknameState, complete]);
+  }, [passwordState, password2State, nicknameState, complete]);
 
-  /* ID의 유효성 검사 */
-  useEffect(() => {
-    const IDcheck = /@korea\.ac\.kr$/;
-    if (IDState === "filled") {
-      if (!IDcheck.test(ID)) setIDState("error");
-      else setIDState("filled");
-    }
-  }, [ID, IDState]);
-
-  /* password의 유효성 검사 */
+  /* password의 유효성 검사 + 알맞은 errorMessage 설정 */
   useEffect(() => {
     const passwordCheck =
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()_+{}\[\]:;<>,.?~\-]).{8,}$/;
     if (passwordState === "filled") {
-      if (!passwordCheck.test(password)) setPasswordState("error");
-      else setPasswordState("filled");
+      if (!passwordCheck.test(password)) {
+        let errorMessage = "비밀번호가 ";
+
+        if (!/(?=.*[a-z])/.test(password)) {
+          errorMessage += " 소문자를 포함하고 있지 않아요!";
+        } else if (!/(?=.*[A-Z])/.test(password)) {
+          errorMessage += " 대문자를 포함하고 있지 않아요!";
+        } else if (!/(?=.*[!@#$%^&*()_+{}\[\]:;<>,.?~\-])/.test(password)) {
+          errorMessage += " 특수 문자를 포함하고 있지 않아요!";
+        } else if (password.length < 8)
+          errorMessage += " 최소 8자 이상이어야 해요!";
+        setErrorMessages({
+          ...errorMessages,
+          passwordErrorMessage: errorMessage,
+        });
+        setPasswordState("error");
+      } else setPasswordState("filled");
     }
   }, [password, passwordState]);
-
-  /* password2의 유효성 검사 */
-  useEffect(() => {
-    const password2Check =
-      /^(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()_+{}\[\]:;<>,.?~\-]).{8,}$/;
-    if (password2State === "filled") {
-      if (!password2Check.test(password2)) setPassword2State("error");
-      else setPassword2State("filled");
-    }
-  }, [password2, password2State]);
 
   /* password2의 일치 여부 검사 */
   useEffect(() => {
@@ -277,7 +279,7 @@ export default function SignUp3Page() {
               setState={setPasswordState}
               setValue={setPassword}
               helpMessage="비밀번호는 <8자 이상/1개 이상의 대,소문자/1개 이상의 특수문자>가 포함되어야 합니다."
-              errorMessage="유효하지 않은 비밀번호에요."
+              errorMessage={errorMessages.passwordErrorMessage}
               type="password"
             ></TextFieldBox>
           </ContentsWrapper>

--- a/src/pages/SignUp/SignUp3Page.tsx
+++ b/src/pages/SignUp/SignUp3Page.tsx
@@ -88,6 +88,32 @@ const ButtonsWrapper = styled.div`
   gap: 18px;
   margin-top: 34px;
 `;
+
+const InfoMessageWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  margin-left: 20px;
+`;
+
+const InfoImageWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+`;
+
+const CircleImage = styled.svg`
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+
+const CheckImage = styled.svg`
+  position: absolute;
+  top: 3px;
+  left: 3px;
+`;
+
 // state를 부모 컴포넌트에서 넘겨 주기 위해 추가
 type StateOptions =
   | "default"
@@ -253,10 +279,60 @@ export default function SignUp3Page() {
               setState={() => {}}
               setValue={() => {}}
             ></TextFieldBox>
-            {/* 이미지 추가가 필요해요! */}
-            <Typography size="details" color="#A8A8A8">
-              쿠플라이 아이디는 고려대학교 이메일입니다.
-            </Typography>
+            <InfoMessageWrapper>
+              <InfoImageWrapper>
+                <CircleImage
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                >
+                  <g clip-path="url(#clip0_2213_3136)">
+                    <path
+                      d="M6 11C8.76142 11 11 8.76142 11 6C11 3.23858 8.76142 1 6 1C3.23858 1 1 3.23858 1 6C1 8.76142 3.23858 11 6 11Z"
+                      stroke="#A8A8A8"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </g>
+                  <defs>
+                    <clipPath id="clip0_2213_3136">
+                      <rect width="12" height="12" fill="white" />
+                    </clipPath>
+                  </defs>
+                </CircleImage>
+                <CheckImage
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="6"
+                  height="6"
+                  viewBox="0 0 6 6"
+                  fill="none"
+                >
+                  <g clip-path="url(#clip0_2213_3138)">
+                    <path
+                      d="M4.66659 1.75L2.37492 4.04167L1.33325 3"
+                      stroke="#A8A8A8"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </g>
+                  <defs>
+                    <clipPath id="clip0_2213_3138">
+                      <rect
+                        width="5"
+                        height="5"
+                        fill="white"
+                        transform="translate(0.5 0.5)"
+                      />
+                    </clipPath>
+                  </defs>
+                </CheckImage>
+              </InfoImageWrapper>
+              <Typography size="details" color="#A8A8A8">
+                쿠플라이 아이디는 고려대학교 이메일입니다.
+              </Typography>
+            </InfoMessageWrapper>
           </ContentsWrapper>
           <ContentsWrapper>
             <div style={{ display: "flex" }}>


### PR DESCRIPTION
1. ErrorMessage 위치를 Textfield의 Text가 시작되는 지점으로 변경하여 둘의 시작 지점이 일치되도록 정렬하였습니다.
2. Password의 ErrorMessage를 소문자 없음, 대문자 없음, 특수문자 없음, 길이 8자 미만 네 개로 세분화하여 출력하도록 수정하였습니다.
3. Page 3에서 쿠플라이 아이디 text 밑의 회색 텍스트 왼쪽에 이미지를 추가하였습니다.
4. 기존 Dropdown에서 아래쪽에 의도치 않은 공간이 생겼었는데 이를 다시 없앴습니다.

Password 눈 버튼이랑 닉네임 중복 확인 버튼은 디자인 나오는 대로 반영해 보도록 하겠습니다